### PR TITLE
Added Minimum Beat

### DIFF
--- a/RevealingSplashView/Animations.swift
+++ b/RevealingSplashView/Animations.swift
@@ -293,7 +293,7 @@ public extension SplashAnimatable where Self: UIView {
                 animation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
                 animation.duration = CFTimeInterval(self.duration/2)
                 animation.isAdditive = true
-                animation.repeatCount = 1
+                animation.repeatCount = Float(minimumBeats > 0 ? minimumBeats : 1)
                 animation.beginTime = CACurrentMediaTime() + CFTimeInterval(self.delay/2)
                 imageView.layer.add(animation, forKey: "pop")
                 }, completion: { [weak self] in 

--- a/RevealingSplashView/RevealingSplashView.swift
+++ b/RevealingSplashView/RevealingSplashView.swift
@@ -78,6 +78,9 @@ open class RevealingSplashView: UIView, SplashAnimatable{
     /// The boolean to stop the heart beat animation, default to false (continuous beat)
     open var heartAttack: Bool = false
     
+    /// The repeat counter for heart beat animation, default to 1
+    open var minimumBeats: Int = 1
+    
     /**
      Default constructor of the class
      

--- a/RevealingSplashView/SplashAnimatable.swift
+++ b/RevealingSplashView/SplashAnimatable.swift
@@ -29,4 +29,7 @@ public protocol SplashAnimatable: class{
     
     /// The trigger to stop heartBeat animation
     var heartAttack: Bool { get set }
+    
+    /// The minimum number of beats before removing the splash view
+    var minimumBeats: Int { get set }
 }


### PR DESCRIPTION
Considering most apps are very fast in network requests, this will give the option of intentionally forcing a few beats (1 or more) before loading the main screen
