### PR TITLE
make enum cases lowerCamelCase

### DIFF
--- a/RevealingSplashView/Animations.swift
+++ b/RevealingSplashView/Animations.swift
@@ -21,25 +21,25 @@ public extension SplashAnimatable where Self: UIView {
     public func startAnimation(_ completion: SplashAnimatableCompletion? = nil)
     {
         switch animationType{
-        case .Twitter:
+        case .twitter:
             playTwitterAnimation(completion)
             
-        case .RotateOut:
+        case .rotateOut:
             playRotateOutAnimation(completion)
             
-        case .WoobleAndZoomOut:
+        case .woobleAndZoomOut:
             playWoobleAnimation(completion)
             
-        case .SwingAndZoomOut:
+        case .swingAndZoomOut:
             playSwingAnimation(completion)
             
-        case.PopAndZoomOut:
+        case .popAndZoomOut:
             playPopAnimation(completion)
             
-        case.SqueezeAndZoomOut:
+        case .squeezeAndZoomOut:
             playSqueezeAnimation(completion)
             
-        case.HeartBeat:
+        case .heartBeat:
             playHeartBeatAnimation(completion)
         }
         

--- a/RevealingSplashView/RevealingSplashView.swift
+++ b/RevealingSplashView/RevealingSplashView.swift
@@ -66,10 +66,10 @@ open class RevealingSplashView: UIView, SplashAnimatable{
     /// THe image view containing the icon Image
     open var imageView: UIImageView?
     
-    /// The type of animation to use for the. Defaults to the Twitter default animation
-    open var animationType: SplashAnimationType = SplashAnimationType.Twitter
+    /// The type of animation to use for the. Defaults to the twitter default animation
+    open var animationType: SplashAnimationType = SplashAnimationType.twitter
     
-    /// The duration of the animation, default to 1.5 seconds. In the case of HeartBeat animation recommended value is 3
+    /// The duration of the animation, default to 1.5 seconds. In the case of heartBeat animation recommended value is 3
     open var duration: Double = 1.5
     
     /// The delay of the animation, default to 0.5 seconds

--- a/RevealingSplashView/SplashAnimationType.swift
+++ b/RevealingSplashView/SplashAnimationType.swift
@@ -15,12 +15,12 @@ import Foundation
  */
 public enum SplashAnimationType: String{
     
-    case Twitter
-    case RotateOut
-    case WoobleAndZoomOut
-    case SwingAndZoomOut
-    case PopAndZoomOut
-    case SqueezeAndZoomOut
-    case HeartBeat
+    case twitter
+    case rotateOut
+    case woobleAndZoomOut
+    case swingAndZoomOut
+    case popAndZoomOut
+    case squeezeAndZoomOut
+    case heartBeat
     
 }

--- a/RevealingSplashViewSample/ViewController.swift
+++ b/RevealingSplashViewSample/ViewController.swift
@@ -23,7 +23,7 @@ class ViewController: UIViewController {
         revealingSplashView.iconColor = UIColor.red
         revealingSplashView.useCustomIconColor = false
         
-        revealingSplashView.animationType = SplashAnimationType.SwingAndZoomOut
+        revealingSplashView.animationType = SplashAnimationType.swingAndZoomOut
     
         revealingSplashView.startAnimation(){
             

--- a/RevealingSplashViewTests/RevealingSplashViewSpecs.swift
+++ b/RevealingSplashViewTests/RevealingSplashViewSpecs.swift
@@ -36,7 +36,7 @@ class RevealingSplashViewSpecs: QuickSpec {
             
             
             expect(revealingSplashView).notTo(beNil())
-            expect(revealingSplashView.animationType).to(equal(SplashAnimationType.Twitter))
+            expect(revealingSplashView.animationType).to(equal(SplashAnimationType.twitter))
         
             expect(revealingSplashView.imageView?.tintColor).to(equal(UIColor.white))
         }
@@ -56,7 +56,7 @@ class RevealingSplashViewSpecs: QuickSpec {
         
         it("pop animation completes") {
                 
-                revealingSplashView.animationType = SplashAnimationType.PopAndZoomOut
+                revealingSplashView.animationType = SplashAnimationType.popAndZoomOut
                 
                 revealingSplashView.duration = 3
                 
@@ -65,14 +65,14 @@ class RevealingSplashViewSpecs: QuickSpec {
                         completed = true
                 }
                 
-                expect(revealingSplashView.animationType).to(equal(SplashAnimationType.PopAndZoomOut))
+                expect(revealingSplashView.animationType).to(equal(SplashAnimationType.popAndZoomOut))
                 expect(completed).toEventually(beTrue(),timeout:3)
                 
         }
         
         it("squeeze animation completes") {
                 
-                revealingSplashView.animationType = SplashAnimationType.SqueezeAndZoomOut
+                revealingSplashView.animationType = SplashAnimationType.squeezeAndZoomOut
                 
                 revealingSplashView.duration = 3
                 
@@ -81,14 +81,14 @@ class RevealingSplashViewSpecs: QuickSpec {
                         completed = true
                 }
                 
-            expect(revealingSplashView.animationType).to(equal(SplashAnimationType.SqueezeAndZoomOut))
+            expect(revealingSplashView.animationType).to(equal(SplashAnimationType.squeezeAndZoomOut))
             expect(completed).toEventually(beTrue(),timeout:3)
                 
         }
         
         it("Rotate out animation completes") {
                 
-                revealingSplashView.animationType = SplashAnimationType.RotateOut
+                revealingSplashView.animationType = SplashAnimationType.rotateOut
                 
                 revealingSplashView.duration = 3
                 
@@ -97,7 +97,7 @@ class RevealingSplashViewSpecs: QuickSpec {
                         completed = true
                 }
                 
-            expect(revealingSplashView.animationType).to(equal(SplashAnimationType.RotateOut))
+            expect(revealingSplashView.animationType).to(equal(SplashAnimationType.rotateOut))
             expect(completed).toEventually(beTrue(),timeout:3)
                 
         }
@@ -105,7 +105,7 @@ class RevealingSplashViewSpecs: QuickSpec {
         
         it("Wobble out animation completes") {
             
-            revealingSplashView.animationType = SplashAnimationType.WoobleAndZoomOut
+            revealingSplashView.animationType = SplashAnimationType.woobleAndZoomOut
             
             revealingSplashView.duration = 1
             
@@ -114,7 +114,7 @@ class RevealingSplashViewSpecs: QuickSpec {
                     completed = true
             }
             
-            expect(revealingSplashView.animationType).to(equal(SplashAnimationType.WoobleAndZoomOut))
+            expect(revealingSplashView.animationType).to(equal(SplashAnimationType.woobleAndZoomOut))
             expect(completed).toEventually(beTrue(),timeout:1)
             
         }
@@ -122,7 +122,7 @@ class RevealingSplashViewSpecs: QuickSpec {
         
         it("Swing out animation completes") {
             
-            revealingSplashView.animationType = SplashAnimationType.SwingAndZoomOut
+            revealingSplashView.animationType = SplashAnimationType.swingAndZoomOut
             
             revealingSplashView.duration = 2
             
@@ -131,7 +131,7 @@ class RevealingSplashViewSpecs: QuickSpec {
                     completed = true
             }
             
-            expect(revealingSplashView.animationType).to(equal(SplashAnimationType.SwingAndZoomOut))
+            expect(revealingSplashView.animationType).to(equal(SplashAnimationType.swingAndZoomOut))
             expect(completed).toEventually(beTrue(),timeout:2)
             
         }


### PR DESCRIPTION
I rename enums to `lowerCamelCase`.

It is described as follows:

> Follow case conventions. Names of types and protocols are UpperCamelCase. Everything else is lowerCamelCase.
> [Swift 3 API Design Guidelines / conventions](https://swift.org/documentation/api-design-guidelines/#conventions)
