### PR TITLE
Fade in Status Bar After Animation Completion

### DIFF
--- a/RevealingSplashViewSample/Info.plist
+++ b/RevealingSplashViewSample/Info.plist
@@ -20,6 +20,8 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>UIStatusBarHidden</key>
+	<true/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/RevealingSplashViewSample/ViewController.swift
+++ b/RevealingSplashViewSample/ViewController.swift
@@ -26,18 +26,17 @@ class ViewController: UIViewController {
         revealingSplashView.animationType = SplashAnimationType.SwingAndZoomOut
     
         revealingSplashView.startAnimation(){
-            
+            self.setNeedsStatusBarAppearanceUpdate()
             print("Completed")
         }
-        
-        // Do any additional setup after loading the view, typically from a nib.
     }
-
-    override func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
-        // Dispose of any resources that can be recreated.
+    
+    override var prefersStatusBarHidden: Bool {
+        return !UIApplication.shared.isStatusBarHidden
     }
-
-
+    
+    override var preferredStatusBarUpdateAnimation: UIStatusBarAnimation {
+        return UIStatusBarAnimation.fade
+    }
 }
 


### PR DESCRIPTION
Added a fade of the status bar after the animation completes + initially hid the status bar in the sample app.
